### PR TITLE
fix: wait for all goroutines to finish before exiting

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    if:
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]'))
     timeout-minutes: 15
     steps:
       - uses: coderabbitai/openai-pr-reviewer@latest

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -2,11 +2,9 @@
 name: ai-pr-reviewer
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
-    types: [created]
-  issue_comment:
     types: [created]
 
 permissions:
@@ -22,9 +20,6 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if:
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]'))
     timeout-minutes: 15
     steps:
       - uses: coderabbitai/openai-pr-reviewer@latest

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,6 +21,3 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  release:
-    needs: bump
-    uses: ./.github/workflows/releaser.yml

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - "*"
-  workflow_call:
 
 permissions:
   contents: write

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -27,8 +27,9 @@ func main() {
 
 	tlsConfig, err := newTLSConfig("emqxsl-ca.crt")
 	if err != nil {
-		log.Info().Msg("TLS enabled")
+		log.Error().Msgf("error creating TLS config: %s\n", err)
 	}
+	log.Info().Msgf("TLS config: %v\n", tlsConfig)
 
 	cfg, err := getConfig()
 	if err != nil {
@@ -132,15 +133,13 @@ func main() {
 					log.Info().Msg("publisher done")
 					return
 				}
-				wg.Wait()
 			}
 		}
 	}()
 
 	// Wait for a signal before exiting
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt)
-	signal.Notify(sig, syscall.SIGTERM)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
 	<-sig
 	log.Info().Msg("signal caught - exiting")

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -132,8 +132,8 @@ func main() {
 					log.Info().Msg("publisher done")
 					return
 				}
+				wg.Wait()
 			}
-			wg.Wait()
 		}
 	}()
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug fix: `main.go`のゴルーチンが完了するまでプログラムが待機するように修正しました。これにより、プログラムが終了する前にすべてのゴルーチンが完了することを保証します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->