### PR TITLE
fix: add caFile to config

### DIFF
--- a/publisher/config.go
+++ b/publisher/config.go
@@ -51,7 +51,7 @@ func getConfig() (config, error) {
 	var cfg config
 	var err error
 
-	srvURL, err := stringFromEnv(envServerURL)
+	srvURL, err := requiredStringFromEnv(envServerURL)
 	if err != nil {
 		return config{}, err
 	}
@@ -60,19 +60,18 @@ func getConfig() (config, error) {
 		return config{}, fmt.Errorf("environmental variable %s must be a valid URL (%w)", envServerURL, err)
 	}
 
-	if cfg.caFile, err = stringFromEnv(envCAFile); err != nil {
+	cfg.caFile = stringFromEnv(envCAFile)
+
+	if cfg.clientID, err = requiredStringFromEnv(envClientID); err != nil {
 		return config{}, err
 	}
-	if cfg.clientID, err = stringFromEnv(envClientID); err != nil {
+	if cfg.username, err = requiredStringFromEnv(envUsername); err != nil {
 		return config{}, err
 	}
-	if cfg.username, err = stringFromEnv(envUsername); err != nil {
+	if cfg.password, err = requiredStringFromEnv(envPassword); err != nil {
 		return config{}, err
 	}
-	if cfg.password, err = stringFromEnv(envPassword); err != nil {
-		return config{}, err
-	}
-	if cfg.topic, err = stringFromEnv(envTopic); err != nil {
+	if cfg.topic, err = requiredStringFromEnv(envTopic); err != nil {
 		return config{}, err
 	}
 
@@ -107,8 +106,13 @@ func getConfig() (config, error) {
 	return cfg, nil
 }
 
-// stringFromEnv - Retrieves a string from the environment and ensures it is not blank (ort non-existent)
-func stringFromEnv(key string) (string, error) {
+// stringFromEnv gets a string from the environment or returns an empty string if not set.
+func stringFromEnv(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
+// requiredStringFromEnv - Retrieves a string from the environment and ensures it is not blank (ort non-existent)
+func requiredStringFromEnv(key string) (string, error) {
 	s := os.Getenv(key)
 	if len(s) == 0 {
 		return "", fmt.Errorf("environmental variable %s must not be blank", key)

--- a/publisher/config.go
+++ b/publisher/config.go
@@ -14,6 +14,7 @@ import (
 // Configuration will be pulled from the environment using the following keys
 const (
 	envServerURL = "acm_serverURL" // server URL
+	envCAFile    = "acm_caFile"    // CA file to use when connecting to server
 	envClientID  = "acm_clientID"  // client id to connect with
 	envUsername  = "acm_username"  // username to connect with
 	envPassword  = "acm_password"  // password to connect with
@@ -31,6 +32,7 @@ const (
 // config holds the configuration
 type config struct {
 	serverURL *url.URL // MQTT server URL
+	caFile    string   // CA file to use when connecting to server
 	clientID  string   // Client ID to use when connecting to server
 	username  string   // Username to use when connecting to server
 	password  string   // Password to use when connecting to server
@@ -58,6 +60,9 @@ func getConfig() (config, error) {
 		return config{}, fmt.Errorf("environmental variable %s must be a valid URL (%w)", envServerURL, err)
 	}
 
+	if cfg.caFile, err = stringFromEnv(envCAFile); err != nil {
+		return config{}, err
+	}
 	if cfg.clientID, err = stringFromEnv(envClientID); err != nil {
 		return config{}, err
 	}

--- a/publisher/config_test.go
+++ b/publisher/config_test.go
@@ -300,7 +300,7 @@ func TestStringFromEnv(t *testing.T) {
 			wantValue: "SMALLPOX",
 		},
 		{
-			name:      "value must not be blank",
+			name:      "value must be blank",
 			key:       "smallpox",
 			value:     "",
 			wantValue: "",

--- a/publisher/config_test.go
+++ b/publisher/config_test.go
@@ -11,6 +11,7 @@ func TestGetConfig(t *testing.T) {
 	tests := []struct {
 		name                 string
 		serverURL            string
+		caFile               string
 		clientID             string
 		username             string
 		password             string
@@ -27,6 +28,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "standerd case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -41,6 +43,7 @@ func TestGetConfig(t *testing.T) {
 				serverURL: &url.URL{
 					Scheme: "http",
 					Host:   "localhost:1883"},
+				caFile:               "ca.pem",
 				clientID:             "publisher00001",
 				username:             "user",
 				password:             "pass",
@@ -57,6 +60,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "serverURL must not be blank case",
 			serverURL:            "",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -73,6 +77,24 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "must be a valid URL case",
 			serverURL:            ":",
+			caFile:               "ca.pem",
+			clientID:             "publisher00001",
+			username:             "user",
+			password:             "pass",
+			topic:                "/example/#",
+			qos:                  "0",
+			keepAlive:            "30",
+			connectRetryDelay:    "30",
+			delayBetweenMessages: "15",
+			printMessages:        "true",
+			debug:                "false",
+			wantConfig:           config{},
+			isErr:                true,
+		},
+		{
+			name:                 "caFile must not be blank case",
+			serverURL:            "http://localhost:1883",
+			caFile:               "",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -89,6 +111,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "clientID must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "",
 			username:             "user",
 			password:             "pass",
@@ -105,6 +128,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "topic must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -121,6 +145,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "qos must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -137,6 +162,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "keepAlive must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -153,6 +179,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "connectRetryDelay  must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -169,6 +196,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "delayBetweenMessages must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -185,6 +213,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "printMessages must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -201,6 +230,7 @@ func TestGetConfig(t *testing.T) {
 		{
 			name:                 "debug must not be blank case",
 			serverURL:            "http://localhost:1883",
+			caFile:               "ca.pem",
 			clientID:             "publisher00001",
 			username:             "user",
 			password:             "pass",
@@ -219,6 +249,7 @@ func TestGetConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("acm_serverURL", tt.serverURL)
+			t.Setenv("acm_caFile", tt.caFile)
 			t.Setenv("acm_clientID", tt.clientID)
 			t.Setenv("acm_username", tt.username)
 			t.Setenv("acm_password", tt.password)

--- a/publisher/config_test.go
+++ b/publisher/config_test.go
@@ -105,8 +105,23 @@ func TestGetConfig(t *testing.T) {
 			delayBetweenMessages: "15",
 			printMessages:        "true",
 			debug:                "false",
-			wantConfig:           config{},
-			isErr:                true,
+			wantConfig: config{
+				serverURL: &url.URL{
+					Scheme: "http",
+					Host:   "localhost:1883"},
+				caFile:               "",
+				clientID:             "publisher00001",
+				username:             "user",
+				password:             "pass",
+				topic:                "/example/#",
+				qos:                  byte(0),
+				keepAlive:            30,
+				connectRetryDelay:    time.Duration(30) * time.Millisecond,
+				delayBetweenMessages: time.Duration(15) * time.Millisecond,
+				printMessage:         true,
+				debug:                false,
+			},
+			isErr: false,
 		},
 		{
 			name:                 "clientID must not be blank case",
@@ -277,6 +292,38 @@ func TestStringFromEnv(t *testing.T) {
 		key       string
 		value     string
 		wantValue string
+	}{
+		{
+			name:      "get value",
+			key:       "smallpox",
+			value:     "SMALLPOX",
+			wantValue: "SMALLPOX",
+		},
+		{
+			name:      "value must not be blank",
+			key:       "smallpox",
+			value:     "",
+			wantValue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.key, tt.value)
+			got := stringFromEnv(tt.key)
+			if got != tt.wantValue {
+				t.Fatalf("unexpected value: got: %s, want: %s", got, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestRequiredStringFromEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		value     string
+		wantValue string
 		isErr     bool
 	}{
 		{
@@ -298,7 +345,7 @@ func TestStringFromEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(tt.key, tt.value)
-			got, err := stringFromEnv(tt.key)
+			got, err := requiredStringFromEnv(tt.key)
 			if got != tt.wantValue {
 				t.Fatalf("unexpected value: got: %s, want: %s", got, tt.wantValue)
 			}

--- a/publisher/config_test.go
+++ b/publisher/config_test.go
@@ -92,7 +92,7 @@ func TestGetConfig(t *testing.T) {
 			isErr:                true,
 		},
 		{
-			name:                 "caFile must not be blank case",
+			name:                 "caFile must be a blank case",
 			serverURL:            "http://localhost:1883",
 			caFile:               "",
 			clientID:             "publisher00001",

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -25,18 +25,17 @@ func main() {
 	// Default level for this example is info, unless debug flag is present
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
-	tlsConfig, err := newTLSConfig("/home/alarm/acm/bin/emqxsl-ca.crt")
-	if err != nil {
-		log.Error().Msgf("error creating TLS config: %s", err)
-		return
-	}
-	log.Debug().Msgf("TLS config: %v", tlsConfig)
-
 	cfg, err := getConfig()
 	if err != nil {
 		log.Error().Msgf("error getting config: %s", err)
 		return
 	}
+
+	tlsConfig, err := newTLSConfig(cfg.caFile)
+	if err != nil {
+		log.Info().Msgf("TLS config: %s", err)
+	}
+	log.Debug().Msgf("TLS config: %v", tlsConfig)
 
 	cliCfg := autopaho.ClientConfig{
 		BrokerUrls:        []*url.URL{cfg.serverURL},

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -28,7 +28,7 @@ func main() {
 	cfg, err := getConfig()
 	if err != nil {
 		log.Error().Msgf("error getting config: %s", err)
-		return
+		os.Exit(1)
 	}
 
 	tlsConfig, err := newTLSConfig(cfg.caFile)


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: `config`構造体に`caFile`フィールドを追加し、環境変数からその値を取得するようにしました。
- Refactor: ハードコーディングされたCAファイルパスを削除し、設定から取得するように変更しました。
- Test: `getConfig`と`requiredStringFromEnv`関数の新しいテストケースを追加しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->